### PR TITLE
Added test for rerun button related to Bugfix#209

### DIFF
--- a/02 Nightwatch/src/scripts/UI/tests/test.js
+++ b/02 Nightwatch/src/scripts/UI/tests/test.js
@@ -35,4 +35,24 @@ module.exports = {
       .assert.visible("#test-reports-page")
       .assert.hidden("#start-tests-page")
   },
+
+  'Re-run test': (browser) => {
+    browser
+      .url(URL)
+      .waitForElementVisible(".ui-block-c")
+      .click(".ui-block-c")
+      .waitForElementVisible('#test-reports-page',10000)
+      .assert.visible('#test-reports-page')
+      .assert.hidden('#start-tests-page')
+      .useXpath()
+      .click('xpath','/html/body/div[4]/div[2]/ul/li[2]/h2/a')
+      .waitForElementPresent('/html/body/div[4]/div[2]/ul/li[2]/div/div/div[2]/a[5]',10000)
+      .click('xpath','/html/body/div[4]/div[2]/ul/li[2]/div/div/div[2]/a[5]')
+      .waitForElementVisible('/html/body/div[12]/div[2]/div[1]/div[3]/div/fieldset[1]/div[2]/div[1]/label',20000)
+      .click('xpath','/html/body/div[12]/div[2]/div[1]/div[3]/div/fieldset[1]/div[2]/div[1]/label')
+      .waitForElementVisible('/html/body/div[12]/div[2]/div[1]/div[1]/div/table/tbody/tr[6]/td[2]/a',10000)
+      .click('xpath','/html/body/div[12]/div[2]/div[1]/div[1]/div/table/tbody/tr[6]/td[2]/a')
+      .waitForElementVisible('/html/body/pre',10000)
+      .assert.not.containsText('/html/body/pre','NullPointerException')
+  },
 };


### PR DESCRIPTION
To test the pull request https://github.com/etf-validator/etf-webapp/pull/217, we have included an UI test on Nightwatch.

The tests expects to have a WFS 2.0 (OGC 09-025r2/ISO 19142) Conformance Test Suite already executed and available to perform a rerun test. We were unable to perform the full cycle of TestRun creation and deletion of TestObjects through the API in Nightwatch.

We added the assertions to check that the rerun button actually starts the TestRun, and there is no NullPointerException.